### PR TITLE
Integrated Civil Comments js to render in field widget.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+
+php:
+  - 5.6
+
+install:
+- composer global require drupal/coder >2
+- composer global require drupal/coder 8.*
+
+script:
+  - ~/.composer/vendor/bin/phpcs --standard=~/.composer/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml -v .

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ php:
   - 5.6
 
 install:
-- composer global require drupal/coder >2
-- composer global require drupal/coder 8.*
+  - composer global require drupal/coder >2
+  - composer global require drupal/coder 8.*
 
 script:
   - ~/.composer/vendor/bin/phpcs --standard=~/.composer/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml -v .

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# civilcomments
-Drupal module for the Civil Comments platform
+# Civil Comments
+
+[Civil Comments](https://www.civilcomments.com) is a platform that brings real-world social cues to comments sections via crowd-sourced moderation and powerful community management tools. Civil Comments is the first commenting platform _specifically designed_ to improve the way people treat each other online.
+
+_PLEASE NOTE: There is not currently a free version of Civil Comments. For the time being, it is only available with a subscription._
+
+### Drupal Integration
+* Provides a Civil Comments field type that can be added to any fieldable entity.
+* TKTK
+
+### Installation</h3>
+* Register your site at [civilcomments.com](https://www.civilcomments.com)
+* Download and install the Civil Comments module.
+* Configure your Civil Comments' site id, content id, and language code at `admin/config/system/civilcomments`.
+* TKTK

--- a/civilcomments.install
+++ b/civilcomments.install
@@ -12,7 +12,6 @@ function civilcomments_uninstall() {
   // Remove the site-wide account settings.
   \Drupal::configFactory()->getEditable('civilcomments.settings')
     ->clear('civilcomments_site_id')
-    ->clear('civilcomments_content_id')
     ->clear('civilcomments_lang')
     ->save();
 }

--- a/civilcomments.libraries.yml
+++ b/civilcomments.libraries.yml
@@ -1,0 +1,6 @@
+civilcomments.default:
+  version: 1.x
+  js:
+    js/civilcomments.js: {}
+  dependencies:
+    - core/drupalSettings

--- a/civilcomments.permissions.yml
+++ b/civilcomments.permissions.yml
@@ -2,6 +2,6 @@ administer civilcomments:
   title: 'Administer Civil Comments'
   description: 'Allows users to configure Civil Comments.'
   restrict access: TRUE
-post civilcomments:
-  title: 'Post Civil Comments'
-  description: 'Allows users to post Civil Comments.'
+view civilcomments:
+  title: 'View Civil Comments'
+  description: 'Allows users to view Civil Comments.'

--- a/civilcomments.permissions.yml
+++ b/civilcomments.permissions.yml
@@ -2,3 +2,6 @@ administer civilcomments:
   title: 'Administer Civil Comments'
   description: 'Allows users to configure Civil Comments.'
   restrict access: TRUE
+post civilcomments:
+  title: 'Post Civil Comments'
+  description: 'Allows users to post Civil Comments.'

--- a/config/install/civilcomments.settings.yaml
+++ b/config/install/civilcomments.settings.yaml
@@ -1,3 +1,2 @@
 civilcomments_site_id: ''
-civilcomments_content_id: ''
 civilcomments_lang: ''

--- a/config/schema/civilcomments.schema.yml
+++ b/config/schema/civilcomments.schema.yml
@@ -4,7 +4,5 @@ civilcomments.settings:
   mapping:
     civilcomments_site_id:
       type: string
-    civilcomments_content_id:
-      type: string
     civilcomments_lang:
       type: string

--- a/js/civilcomments.js
+++ b/js/civilcomments.js
@@ -1,0 +1,18 @@
+/**
+ * @file
+ * civilcomments.js
+ */
+
+(function(c, o, m, e, n, t, s){
+  c[n] = c[n] || function() {
+    var args = [].slice.call(arguments);
+    (c[n].q = c[n].q || []).push(args)
+    t = o.createElement(m);
+    s = o.getElementsByTagName(m)[0];
+    t.async = 1;
+    t.src = [e].concat(args).join("/");
+    s.parentNode.insertBefore(t, s);
+  };
+  c["CivilCommentsObject"] = c[n];
+})(window, document, "script", "https://ssr.civilcomments.com/v1", "Civil");
+Civil(drupalSettings.civilcomments.site_id,drupalSettings.civilcomments.content_id,drupalSettings.civilcomments.lang);

--- a/js/civilcomments.js
+++ b/js/civilcomments.js
@@ -15,4 +15,4 @@
   };
   c["CivilCommentsObject"] = c[n];
 })(window, document, "script", "https://ssr.civilcomments.com/v1", "Civil");
-Civil(drupalSettings.civilcomments.site_id,drupalSettings.civilcomments.content_id,drupalSettings.civilcomments.lang);
+Civil(drupalSettings.civilcomments.content_id,drupalSettings.civilcomments.site_id,drupalSettings.civilcomments.lang);

--- a/src/Form/CivilCommentsSettingsForm.php
+++ b/src/Form/CivilCommentsSettingsForm.php
@@ -33,13 +33,12 @@ class CivilCommentsSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, \Drupal\Core\Form\FormStateInterface $form_state) {
-
+  public function buildForm(array $form, FormStateInterface $form_state) {
     // Add form elements to collect site account information.
     $form['account'] = [
       '#type' => 'details',
       '#title' => $this->t('Default account settings'),
-      '#description' => $this->t('You will need an active subscription to Civil Comments, and the Site ID associated with your subscription.'),
+      '#description' => $this->t('You will need an active subscription to <a href=":url">Civil Comments</a>, and the Site ID associated with your subscription.', [':url' => 'https://www.civilcomments.com/']),
       '#open' => TRUE,
     ];
 
@@ -58,6 +57,7 @@ class CivilCommentsSettingsForm extends ConfigFormBase {
     $form['account']['civilcomments_lang'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Site Language'),
+      '#description' => $this->t('A two digit language code.'),
       '#default_value' => \Drupal::config('civilcomments.settings')->get('civilcomments_lang'),
     ];
 

--- a/src/Form/CivilCommentsSettingsForm.php
+++ b/src/Form/CivilCommentsSettingsForm.php
@@ -9,7 +9,6 @@ namespace Drupal\civilcomments\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Url;
 
 /**
  * Civil Comments configuration settings form.
@@ -70,4 +69,5 @@ class CivilCommentsSettingsForm extends ConfigFormBase {
 
     parent::submitForm($form, $form_state);
   }
+
 }

--- a/src/Form/CivilCommentsSettingsForm.php
+++ b/src/Form/CivilCommentsSettingsForm.php
@@ -48,12 +48,6 @@ class CivilCommentsSettingsForm extends ConfigFormBase {
       '#default_value' => \Drupal::config('civilcomments.settings')->get('civilcomments_site_id'),
     ];
 
-    $form['account']['civilcomments_content_id'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Content ID'),
-      '#default_value' => \Drupal::config('civilcomments.settings')->get('civilcomments_content_id'),
-    ];
-
     $form['account']['civilcomments_lang'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Site Language'),
@@ -71,7 +65,6 @@ class CivilCommentsSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->config('civilcomments.settings')
       ->set('civilcomments_site_id', $form_state->getValue('civilcomments_site_id'))
-      ->set('civilcomments_content_id', $form_state->getValue('civilcomments_content_id'))
       ->set('civilcomments_lang', $form_state->getValue('civilcomments_lang'))
       ->save();
 

--- a/src/Plugin/Field/FieldFormatter/CivilCommentsDefaultFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/CivilCommentsDefaultFormatter.php
@@ -36,8 +36,12 @@ class CivilCommentsDefaultFormatter extends FormatterBase {
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
-    $entity_uuid = $items->getEntity()->uuid();
+    $user = \Drupal::currentUser();
+    if (!$user->hasPermission('view civilcomments')) {
+      return $elements;
+    }
 
+    $entity_uuid = $items->getEntity()->uuid();
     foreach ($items as $delta => $item) {
       $elements[$delta] = [
         '#theme' => 'civilcomments_formatter',

--- a/src/Plugin/Field/FieldFormatter/CivilCommentsDefaultFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/CivilCommentsDefaultFormatter.php
@@ -41,10 +41,19 @@ class CivilCommentsDefaultFormatter extends FormatterBase {
     foreach ($items as $delta => $item) {
       $elements[$delta] = [
         '#theme' => 'civilcomments_formatter',
-        '#content_id' => \Drupal::config('civilcomments.settings')->get('civilcomments_content_id'),
-        '#lang' => \Drupal::config('civilcomments.settings')->get('civilcomments_lang'),
-        '#site_id' => \Drupal::config('civilcomments.settings')->get('civilcomments_site_id'),
         '#status' => $item->status,
+        '#attached' => [
+          'library' => [
+            'civilcomments/civilcomments.default',
+          ],
+          'drupalSettings' => [
+            'civilcomments' => [
+              'site_id' => \Drupal::config('civilcomments.settings')->get('civilcomments_site_id'),
+              'content_id' => \Drupal::config('civilcomments.settings')->get('civilcomments_content_id'),
+              'lang' => \Drupal::config('civilcomments.settings')->get('civilcomments_lang'),
+            ],
+          ],
+        ],
       ];
     }
 

--- a/src/Plugin/Field/FieldFormatter/CivilCommentsDefaultFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/CivilCommentsDefaultFormatter.php
@@ -37,6 +37,7 @@ class CivilCommentsDefaultFormatter extends FormatterBase {
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
+    $entity_uuid = $items->getEntity()->uuid();
 
     foreach ($items as $delta => $item) {
       $elements[$delta] = [
@@ -49,7 +50,7 @@ class CivilCommentsDefaultFormatter extends FormatterBase {
           'drupalSettings' => [
             'civilcomments' => [
               'site_id' => \Drupal::config('civilcomments.settings')->get('civilcomments_site_id'),
-              'content_id' => \Drupal::config('civilcomments.settings')->get('civilcomments_content_id'),
+              'content_id' => $entity_uuid,
               'lang' => \Drupal::config('civilcomments.settings')->get('civilcomments_lang'),
             ],
           ],

--- a/src/Plugin/Field/FieldFormatter/CivilCommentsDefaultFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/CivilCommentsDefaultFormatter.php
@@ -7,7 +7,6 @@
 
 namespace Drupal\civilcomments\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
 

--- a/src/Plugin/Field/FieldType/CivilCommentItemInterface.php
+++ b/src/Plugin/Field/FieldType/CivilCommentItemInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\civilcomments\Plugin\Field\FieldType\CivilCommentItemInterface.
+ */
+
+namespace Drupal\civilcomments\Plugin\Field\FieldType;
+
+/**
+ * Interface definition for Civil Comment items.
+ */
+interface CivilCommentItemInterface {
+
+	/**
+   * Comments for this entity are disabled.
+   */
+  const DISABLED = 0;
+
+  /**
+   * Comments for this entity are closed.
+   */
+  const CLOSED = 1;
+
+  /**
+   * Comments for this entity are open.
+   */
+  const OPEN = 2;
+}

--- a/src/Plugin/Field/FieldType/CivilCommentItemInterface.php
+++ b/src/Plugin/Field/FieldType/CivilCommentItemInterface.php
@@ -12,7 +12,7 @@ namespace Drupal\civilcomments\Plugin\Field\FieldType;
  */
 interface CivilCommentItemInterface {
 
-	/**
+  /**
    * Comments for this entity are disabled.
    */
   const DISABLED = 0;

--- a/src/Plugin/Field/FieldType/CivilCommentItemInterface.php
+++ b/src/Plugin/Field/FieldType/CivilCommentItemInterface.php
@@ -26,4 +26,5 @@ interface CivilCommentItemInterface {
    * Comments for this entity are open.
    */
   const OPEN = 2;
+
 }

--- a/src/Plugin/Field/FieldType/CivilComments.php
+++ b/src/Plugin/Field/FieldType/CivilComments.php
@@ -7,13 +7,9 @@
 
 namespace Drupal\civilcomments\Plugin\Field\FieldType;
 
-use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemBase;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\Element;
-use Drupal\Core\Routing\UrlGeneratorTrait;
-use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\Core\TypedData\DataDefinition;
 
 /**

--- a/src/Plugin/Field/FieldType/CivilComments.php
+++ b/src/Plugin/Field/FieldType/CivilComments.php
@@ -27,7 +27,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   default_formatter = "civilcomments_default"
  * )
  */
-class CivilComments extends FieldItemBase {
+class CivilComments extends FieldItemBase implements CivilCommentItemInterface {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Field/FieldWidget/CivilCommentsDefaultWidget.php
+++ b/src/Plugin/Field/FieldWidget/CivilCommentsDefaultWidget.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\civilcomments\Plugin\Field\FieldWidget;
 
+use Drupal\civilcomments\Plugin\Field\FieldType\CivilCommentItemInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -34,12 +35,15 @@ class CivilCommentsDefaultWidget extends WidgetBase {
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
     $element['status'] = [
-      '#title' => $this->t('Comment status'),
-      '#type' => 'select',
+      '#title' => $this->t('Civil Comments status'),
+      '#type' => 'radios',
       '#options' => [
-        '0' => $this->t('Disabled'),
-        '1' => $this->t('Closed'),
-        '2' => $this->t('Open'),
+        CivilCommentItemInterface::DISABLED => $this->t('Disabled'),
+        CivilCommentItemInterface::CLOSED => $this->t('Closed'),
+        CivilCommentItemInterface::OPEN => $this->t('Open'),
+      ],
+      CivilCommentItemInterface::OPEN => [
+        '#description' => $this->t('Users with the "Post comments" permission can post comments.'),
       ],
       '#default_value' => isset($items[$delta]->status) ? $items[$delta]->status : NULL,
     ];

--- a/src/Plugin/Field/FieldWidget/CivilCommentsDefaultWidget.php
+++ b/src/Plugin/Field/FieldWidget/CivilCommentsDefaultWidget.php
@@ -37,15 +37,17 @@ class CivilCommentsDefaultWidget extends WidgetBase {
     $element['status'] = [
       '#title' => $this->t('Civil Comments status'),
       '#type' => 'radios',
+      '#default_value' => isset($items[$delta]->status) ? $items[$delta]->status : NULL,
       '#options' => [
-        CivilCommentItemInterface::DISABLED => $this->t('Disabled'),
-        CivilCommentItemInterface::CLOSED => $this->t('Closed'),
         CivilCommentItemInterface::OPEN => $this->t('Open'),
+        CivilCommentItemInterface::DISABLED => $this->t('Disabled'),
       ],
       CivilCommentItemInterface::OPEN => [
-        '#description' => $this->t('Users with the "Post comments" permission can post comments.'),
+        '#description' => $this->t('Users with the "View Civil Comments" permission will be able to view and post comments.'),
       ],
-      '#default_value' => isset($items[$delta]->status) ? $items[$delta]->status : NULL,
+      CivilCommentItemInterface::DISABLED => [
+        '#description' => $this->t('Civil Comments will not be displayed.'),
+      ],
     ];
 
     return $element;

--- a/templates/civilcomments-formatter.html.twig
+++ b/templates/civilcomments-formatter.html.twig
@@ -11,4 +11,3 @@
 <div id="civil-comments">
   <noscript>{{ 'Please enable javascript in your browser to view comments.'|t }}</noscript>
 </div>
-<script>console.log('Civil Comments!');</script>


### PR DESCRIPTION
- Added library for Civil Comments js.
- Added permission to post civil comments.
- Added CivilCommentItemInterface to house state constants.
- Removed test code from template.
- Replaced content_id configuration with entity id.
- Added travis PHPCS checking.

Closes #5.

I've also created and began to prep the [project page on D.O.](https://www.drupal.org/sandbox/markdorison/2688726) and a blog post. I think once this is merged we can push it up and promote it to a full project.

![screen shot 2016-03-17 at 10 58 06](https://cloud.githubusercontent.com/assets/20355/13850302/c01fc638-ec2f-11e5-803a-a3d10e2d235e.png)
